### PR TITLE
first pass updating readme and guide docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,14 @@ This repository contains three main things:
 
 1. A python module, called `connectortools` that has some useful functions for using Jupyter Notebooks and JupyterHub in your classes. This is in the `connectortools` folder and can be installed with the `setup.py` script.
 2. A collection of examples for how to use `connectortools`, these are notebooks in the `examples` folder. 
-3. A README with info for teaching data8 connector courses. This is currently in this `README.md` file as well as in the `guide` folder (all can be viewed on Github.com)
+3. A collection of information for teaching data8 connector courses. This is currently in this `README.md` file as well as in the `guide` folder (all can be viewed on Github.com)
 4. A folder (`tutorials`) with general tutorials that cover topics in programming, computation, etc. Connector instructors may find these useful in teaching basic concepts.
+
+## Quick Links
+
+* [Workflow](guide/workflow.md) describes how to create, distribute, and collect class materials with jupyterhub
+* [FAQ](guide/faq.md) contains commonly-asked questions from connector instructors.
+* [Resources](guide/resources.md) has information about computational resources in data8
 
 # Interactive notebooks
 If you're interested in running the tutorials or examples for the `connectortools` module, click the image below to enter an interactive browsing session.
@@ -16,11 +22,6 @@ If you're interested in running the tutorials or examples for the `connectortool
 **Sam Lau** (samlau95@gmail.com) and **Chris Holdgraf** (choldgraf@berkeley.edu) are your current points of contact about issues and questions you may have as a connector instructor. Email us with questions or [ping us on slack][slack].
 
 [slack]: https://data8-connectors.slack.com/messages/general/
-
-## Quick Links
-
-* [Workflow](guide/workflow.md) describes how to create, distribute, and collect class materials with jupyterhub
-* [FAQ](guide/faq.md) contains commonly-asked questions from connector instructors.
 
 ## Who is this for?
 

--- a/guide/casestudies.md
+++ b/guide/casestudies.md
@@ -1,0 +1,2 @@
+# Case studies in Data8 Connectors
+

--- a/guide/docker.md
+++ b/guide/docker.md
@@ -1,0 +1,8 @@
+# A short guide to docker
+
+It would be great if the docker instructions could indicate how to
+- How to install docker (see https://github.com/data-8/data8-notebook)
+- update docker (it asks me every day to update, should I?)
+- update the data8 files in docker (how to keep in sync with any changes to the repo?)
+- stop and restart or just run in the background docker.
+- who to contact with questions/problems and how - email? slack? github issue?

--- a/guide/faq.md
+++ b/guide/faq.md
@@ -1,31 +1,23 @@
-## FAQ
+# FAQ
+If you have a question that isn't answered here or in the guide, either open an issue in this repository, ask on the Slack chatroom, or email the connector assistants.
+
 **Q: Where can I find old materials for this course?**
     
->A: See http://data8.org/fa15/ for the set of materials from Fall 2015. It contains links to topics covered, sample notebooks, homeworks, etc.
-
-**Q: How can I get a new package added to my students' servers?**
-    
->A: Create a new issue in this github repo, and attach a notebook that shows this package to it. We'll try to integrate any additional libraries that your notebook specifies. The more lead time we have the better. Ping Ryan on the issue.*
-
-> When we do update the single user server with new software, it requires that students stop and start their server.
+> A: See http://data8.org/fa15/ for the set of materials from Fall 2015. It contains links to topics covered, sample notebooks, homeworks, etc.
 
 **Q: Where can I find some example notebooks?**
     
->A: **Example notebooks:** For examples of notebooks, you can see
+> A: **Example notebooks:** For examples of notebooks, you can see
 the [table demos][demos] or find all raw notebooks for the textbook [here](https://github.com/data-8/textbook/tree/gh-pages/notebooks). The main class uses notebooks for lectures, labs, and projects.
 
 **Q: How can I more closely follow the class material?**
     
->A: Most of the material will mimic the previous semesters of Data8. However, some material will change (at least in timing if not in content). Those decisions will be made by John close to real time. The best bet is to look at the outline from the syllabus and then find the corresponding sections in [the textbook](http://www.inferentialthinking.com) to see how the material is covered. The textbook is basically the lecture notes from last semester.
+> A: Most of the material will mimic the previous semesters of Data8. However, some material will change (at least in timing if not in content). Those decisions will be made by John close to real time. The best bet is to look at the outline from the syllabus and then find the corresponding sections in [the textbook](http://www.inferentialthinking.com) to see how the material is covered. The textbook is basically the lecture notes from last semester.
 
 **Q: What should I do if students want to join my connector without taking data8**
     
->A: There aren't going to be any "official" course resources for teaching people python/notebook/etc skills if they aren't enrolled in the main data 8 course. If the student has previously taken data8, then it shouldn't be a problem. If they have not taken data8, then:
+> A: There aren't going to be any "official" course resources for teaching people python/notebook/etc skills if they aren't enrolled in the main data 8 course. If the student has previously taken data8, then it shouldn't be a problem. If they have not taken data8, then:
 
->   A. Remind them that the main course is a pre/co-requisite for any connector. (aka it is generally discouraged)
+> A. Remind them that the main course is a pre/co-requisite for any connector. (aka it is generally discouraged)
 
->   B. If they really want to join, then the instructor can make a personal choice whether to include them. We'd recommend that you give some kind of personal assessment, written exam, etc to make sure that it won't create a lot of extra work for the instructor.
-
-**Q: Where can I ask a question that wasn't answered here?**
-    
->A: You can either open an issue in this repository, ask on the Slack chatroom, or email the connector assistants
+> B. If they really want to join, then the instructor can make a personal choice whether to include them. We'd recommend that you give some kind of personal assessment, written exam, etc to make sure that it won't create a lot of extra work for the instructor.

--- a/guide/pedagogy.md
+++ b/guide/pedagogy.md
@@ -1,0 +1,1 @@
+# Teaching an effective data8 class

--- a/guide/resources.md
+++ b/guide/resources.md
@@ -1,0 +1,31 @@
+# Managing resources and data on the cluster
+This is a quick guide on how many resources we have on the cluster, and what considerations you should take in designing your course materials.
+
+# General tips
+* Run your code from start to finish in one go before pushing it to students. This ensures that it runs in a timely fashion, and that you aren't baking memory issues into the code itself.
+* Always run the code on the cluster before distributing it, just in case you haven't accounted for some hardware or library restriction on the cluster.
+
+# Libraries and packages
+To install a new package that all students will have access to, create a new issue in the `connector-instructors` repo and flag the jupyterhub administrator (currently Ryan Lovett). Attach (or point to) a small notebook that uses this package. We'll try to integrate any additional libraries that your notebook specifies. The more lead time we have the better.
+
+Alternatively, it is possible to install packages directly to the data8 cluster. The only trick is that it must be done to your *user* directory, which is generally not the default when using something like `pip`. If you get permissions errors when using `pip`, it's usually because you're trying to write to the base cluster directory, not your user directory.
+
+> When we do update the single user server with new software, it requires that students stop and start their server.
+
+# CPU restrictions
+While CPU will restrict how fast your code runs, it's usually not the bottleneck on the cluster. Obviously you want to limit the complexity of the analyses you'd like students to run, and a good rule of thumb is to try and simplify analyses / datasets, and then discuss how they'd be scaled up. For example, running simple machine learning on in-memory data is probably fine. Fitting a multi-layer neural network on multiple batches of data is probably going to take a long time.
+
+# Memory restrictions
+Memory management is tricky on the cluster. Currently there is 2GB for each student's session (though this may be different in future iterations of the class). In the top-right of notebooks you will find the amount of memory currently used out of the total amount available to students.
+
+## What if I run out of memory?
+* If you run out of memory, the python kernel will automatically restart. This can be frustrating for students because they don't get any kind of message that tells them memory is the problem. It's a good idea to let them know ahead of time.
+* If restarting the kernel and re-running the code doesn't help, then usually there is another notebook open from a previous session. Go to the "running notebooks" page, and close anything you're not using right now.
+* If all other notebooks are closed and you're *still* running out of memory, then log out and log back in to your jupyterhub account. This will close your session and then start a new one. There have been reports of stray memory being taken up by python even though processes have finished running.
+
+# Storing data and I/O
+If you've got data that you want students to use, you have 3 options:
+
+1. Package the data with a github repository. (works if the data is relatively small and won't be modified)
+2. Host the data online somewhere and have students download it. (useful for medium-sized data, and often works well with a helper function you write, e.g. `download_dataset(url)`)
+3. Host the data on the cluster itself, in a shared directory. For this, speak with the cluster administrator to set up a read-only folder that you can direct students towards. (this is best for large datasets on the order of several GB)

--- a/guide/workflow.md
+++ b/guide/workflow.md
@@ -1,4 +1,4 @@
-## Workflow
+# Workflow
 
 Here's a rough overview of the workflow we use in the main class. We'll base the
 rest of this tutorial on these steps. Feel free to add/remove steps as fit for
@@ -21,7 +21,7 @@ Here's a diagram of the steps.
 
 Let's talk in more detail about each of these steps.
 
-### Creating notebooks
+# Creating notebooks
 
 ![step1](https://cloud.githubusercontent.com/assets/2468904/12474029/6d17c1be-bfcc-11e5-80f8-fbc7ff25aa57.png)
 
@@ -29,7 +29,7 @@ This guide is intended for those with **no prior experience** with Jupyter,
 `git`, or Github. Feel free to develop your own workflow if you know what you're
 doing.
 
-#### Setting up your repo
+## Setting up your repo
 
 First, visit https://data8.berkeley.edu/ and log in. You should see a screen that
 looks something like the one below. Click the "Terminal" button as marked:
@@ -51,7 +51,7 @@ are the instructor for the Health connector, you'd write:
 
     git clone https://github.com/data-8/health-connector
 
-#### Adding your content
+## Adding your content
 
 After this step, you should be able to see your connector's folder at
 https://data8.berkeley.edu/ . **Once your folder is there, you do not have to
@@ -83,7 +83,7 @@ use in a notebook, you can upload them using the button as labeled below:
 [demos]: https://github.com/deculler/TableDemos
 [textbook]: http://data8.org/text/
 
-### Pushing your notebooks to Github
+## Pushing your notebooks to Github
 
 ![step2](https://cloud.githubusercontent.com/assets/2468904/12474031/6d1a12e8-bfcc-11e5-83e4-e2dc5b420e6b.png)
 
@@ -131,7 +131,7 @@ http://data8.org/health-connector/Demo2.ipynb .
 If the last step doesn't work, double the check the steps above and contact us
 on a persisting issue.
 
-### Distributing notebooks
+# Distributing notebooks
 
 ![step3](https://cloud.githubusercontent.com/assets/2468904/12474090/f9d45bb2-bfcc-11e5-8884-1ec12945f828.png)
 
@@ -174,7 +174,7 @@ work.
 student delete or rename the bad file/folder, then visit the link again. The
 original file/folder will appear good as new!
 
-### Student work
+# Student work
 
 ![step4](https://cloud.githubusercontent.com/assets/2468904/12474033/6d1d97ce-bfcc-11e5-8fb5-373c31c034b2.png)
 
@@ -201,11 +201,11 @@ related files):
 
     https://data8.berkeley.edu/hub/interact?repo=data8assets&path=labs/lab01
 
-### Student submission
+# Student submission
 
 ![step5](https://cloud.githubusercontent.com/assets/2468904/12474032/6d1a431c-bfcc-11e5-9944-e150c2277eef.png)
 
-Unforunately as of right now we don't have an easy way for students to submit
+As of right now we don't have an easy way for students to submit
 their work programmatically. You can accept submissions through email, bCourses,
 or otherwise.
 


### PR DESCRIPTION
Following #32 this is a first-pass attempt at reorganizing and adding some new information to the README and guide for instructors. Maybe folks there would be interested in giving comments and thoughts. Anything you think would improve this is useful.

All of the additions are in the `guide` section, which is a root-level folder of the repository. I tried to add a few sections that I think would be useful, but that don't have information yet. If you have an idea for how to populate those empty sections with info, then post it here!

Maybe @pattyf @cboettig and @dfeehan have thoughts on stuff specific to course organization / structure / etc, and @ryanlovett and @SamLau95 have thoughts on some of the technical stuff? But chime in wherever it's useful!